### PR TITLE
:wrench: Execute mariadb server (in container) with utf8 as preferred encoding set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
 
   mariadb:
     image: mariadb:10.4
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --init-connect='SET NAMES UTF8;' --innodb-flush-log-at-trx-commit=0
     environment:
       MYSQL_ROOT_PASSWORD: hermes
       MYSQL_DATABASE: hermes


### PR DESCRIPTION
plus collation utf8_unicode_ci