### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'olefile>=0.46,<1.0',
         'html5lib',
         'pandas',
-        'flask_babel==1.0.*',
+        'flask_babel>=1.0.*',
         'records',
         'flask_babel',
         'unidecode',


### PR DESCRIPTION
changed 'flask_babel==1.0.*', to 'flask_babel>=1.0.*'

Automated builds (with up to date OS'es) install 2.0 Which is current version.
If we allow 1.0 (or higher) the automated build should just work.

Could not find things that wont work.

Version got bumped recently from 1.0 to 2.0

https://github.com/python-babel/flask-babel

Hermes uses "Jinja2"  -- Please note that Flask-Babel requires Jinja >=2.5 (form the following site: https://flask-babel.tkte.ch/ )